### PR TITLE
reduce max workers to not surpass AWS vCPU limits

### DIFF
--- a/labs/00-data-prep.ipynb
+++ b/labs/00-data-prep.ipynb
@@ -413,7 +413,7 @@
     "# this includes AWS environment vars needed to access requester-pays and private buckets\n",
     "options.environment_vars.update(dict(os.environ))\n",
     "cluster = gateway.new_cluster(options)\n",
-    "cluster.adapt(minimum=10, maximum=30)\n",
+    "cluster.adapt(minimum=10, maximum=15)\n",
     "\n",
     "# get the client for the cluster\n",
     "client = cluster.get_client()\n",

--- a/labs/01-data-exploration.ipynb
+++ b/labs/01-data-exploration.ipynb
@@ -198,7 +198,7 @@
     "        _env_to_add[_e] = os.environ[_e]\n",
     "_options.environment_vars = _env_to_add\n",
     "cluster = gateway.new_cluster(_options)  ##<< create cluster via the dask gateway\n",
-    "cluster.adapt(minimum=2, maximum=30)  ##<< Sets scaling parameters.\n",
+    "cluster.adapt(minimum=2, maximum=15)  ##<< Sets scaling parameters.\n",
     "\n",
     "client = cluster.get_client()\n",
     "\n",

--- a/labs/03-standard-benchmark.ipynb
+++ b/labs/03-standard-benchmark.ipynb
@@ -350,7 +350,7 @@
     ")\n",
     "options.environment_vars.update(dict(os.environ))\n",
     "cluster = gateway.new_cluster(options)\n",
-    "cluster.adapt(minimum=1, maximum=30)\n",
+    "cluster.adapt(minimum=1, maximum=15)\n",
     "\n",
     "# get the client for the cluster\n",
     "client = cluster.get_client()\n",

--- a/labs/05-dscore-benchmark.ipynb
+++ b/labs/05-dscore-benchmark.ipynb
@@ -333,7 +333,7 @@
     ")\n",
     "options.environment_vars.update(dict(os.environ))\n",
     "cluster = gateway.new_cluster(options)\n",
-    "cluster.adapt(minimum=1, maximum=30)\n",
+    "cluster.adapt(minimum=1, maximum=15)\n",
     "\n",
     "# get the client for the cluster\n",
     "client = cluster.get_client()\n",


### PR DESCRIPTION
Rich messaged me to let me know there’s a quota on how many vCPUs we can spin up at a time in the AWS account that nebari-workshop is running on. I did a little experimentation to estimate a resource usage for a class of 30, and we were going to be way over our allocation limit (assuming all the students are running dask calculations at the exact same time, which they probably will be). I had to bump your max number of workers down to 15 in all of your notebooks to put estimated usage within the range of what we have allocated. I tested out your notebooks and the longest dask calculations (in the standard suite and dscore notebooks) take ~3 mins to run with 15 workers.

Rich put in a request for a higher limit of vCPUs, but it is unlikely to be granted before the workshop. We can leave this as a draft on the off chance they do grant our request before the workshop and don't need to merge. But most likely you will want to merge this PR right before your workshop. Let's be in touch when it gets close to showtime.

To avoid any issues in the class, I would recommend that you really emphasize that students shut down their clusters each time you get to that point in a notebook. I would also recommend that instructors who are watching others present (and not presenting themselves) consider not running the notebooks themselves, just to reduce the usage of resources. (Though based on my estimation, the instructors shouldn't push us over the limit - just wanting to be on the safe side if possible)